### PR TITLE
Incorrect SDM project directory when using cli@1.0.2

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -43,7 +43,7 @@ You'll need [Git][git],
 
 3.  Change into the newly created SDM project.
 
-        cd $HOME/atomist/<target owner>/quick-sdm
+        cd $HOME/atomist/projects/<target owner>/quick-sdm
 
 4.  Start your local SDM.
 


### PR DESCRIPTION
Using cli@1.0.2 installs into $HOME/atomist/projects/<user>/quick-sdm. 

See output: `general 2018-11-16 09:59:30 Created and pushed new project file://Users/xxxxxx/atomist/projects/errrrk/quick-sdm`