### PR TITLE
Generate UX for header link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ markdown_extensions:
   - smarty
   - pymdownx.emoji:
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
+  - toc:
+      permalink: true
 nav:
   - Welcome: index.md
   - Getting Started: getting-started.md


### PR DESCRIPTION
When browsing the docs, I _often_ wish I could link to a header. [mkdocs](https://www.mkdocs.org/user-guide/writing-your-docs/#writing-with-markdown) has a convenient YAML syntax for adding this:

<img width="375" alt="image" src="https://user-images.githubusercontent.com/64050/56682359-63171f80-6699-11e9-8ac2-929019b39f9f.png">

cc @jessitron for 👀 