### PR TITLE
Tutorial: adding a project generator

### DIFF
--- a/docs/developer/create.md
+++ b/docs/developer/create.md
@@ -47,7 +47,7 @@ sdm.addGeneratorCommand(MkdocsSiteGenerator);
 The sample code on this page is about a generator for starting a new documentation site
  like this one.
 
-That `MkdocsSiteGenerator` is a `[GeneratorRegistration][apidoc-generator-registration]`:
+That `MkdocsSiteGenerator` is a `GeneratorRegistration][apidoc-generator-registration]:
 
 ```typescript
 export const MkdocsSiteGenerator: GeneratorRegistration = {

--- a/docs/developer/create.md
+++ b/docs/developer/create.md
@@ -35,40 +35,6 @@ from. This makes a canonical "best starting point" for your organization.
 
 For examples, see all the repositories in our [atomist-seeds organization](https://github.com/atomist-seeds).
 
-## Generator Registration
-
-To add a generator to your SDM, register it where you configure your SDM
-(usually [machine.ts](sdm.md#machinets)):
-
-```typescript
-sdm.addGeneratorCommand(MkdocsSiteGenerator);
-```
-
-The sample code on this page is about a generator for starting a new documentation site
- like this one.
-
-That `MkdocsSiteGenerator` is a `GeneratorRegistration][apidoc-generator-registration]:
-
-```typescript
-export const MkdocsSiteGenerator: GeneratorRegistration = {
-    name: "Mkdocs Site",
-    intent: "create mkdocs site",
-    startingPoint: GitHubRepoRef.from({
-        owner: "atomist-seeds",
-        repo: "mkdocs-site"
-    }),
-    transform: [updateTitle("README.md", "New Project")],
-}
-```
-
-The important elements of a `GeneratorRegistration` are:
-
-* *name* of the generator. This can be any string.
-* *intent* a string or array of strings; type this to trigger the command.
-* *startingPoint* gives the generator a seed.
-Use a pointer to a repository in version control - see [RepoRef](reporef.md) for options.
-* *transform* is an array of zero or more [code transforms](transform.md) to apply.
-
 ## Parameters
 
 Generator commands work the same way as [command parameters](commands.md#command-parameters).

--- a/docs/developer/create.md
+++ b/docs/developer/create.md
@@ -49,7 +49,6 @@ In addition, a generator command automatically gets some parameters that every g
 
 [apidoc-generator-registration]: https://atomist.github.io/sdm/interfaces/_lib_api_registration_generatorregistration_.generatorregistration.html (API Doc for GeneratorRegistration)
 
-
 ## Code sample
 
 Check out [our guide on setting up a generator](/developer/setting-up-generator/) for a complete example.

--- a/docs/developer/create.md
+++ b/docs/developer/create.md
@@ -48,3 +48,8 @@ In addition, a generator command automatically gets some parameters that every g
 | target.visibility | "public" or "private" | what kind of visibility a new repository gets | "private" |
 
 [apidoc-generator-registration]: https://atomist.github.io/sdm/interfaces/_lib_api_registration_generatorregistration_.generatorregistration.html (API Doc for GeneratorRegistration)
+
+
+## Code sample
+
+Check out [our guide on setting up a generator](/developer/setting-up-generator/) for a complete example.

--- a/docs/developer/setting-up-generator.md
+++ b/docs/developer/setting-up-generator.md
@@ -28,7 +28,7 @@ The `GitHubRepoRef` function is going to grab a repository off of GitHub based o
 ```typescript
 export const JavaSpringGenerator: GeneratorRegistration = {
   name: "Java Spring Project",
-  intent: "create java-spring project",
+  intent: "generate-java-spring-project",
   startingPoint: GitHubRepoRef.from({
       owner: "atomist-seeds",
       repo: "spring-rest",
@@ -64,4 +64,29 @@ That's all there is to it!
 
 ## Testing the generator
 
-{!tbd.md!}
+Let's see the command in action.
+
+Start up your SDM in [Local Mode](/developer/local/):
+
+```
+$ atomist start --local
+```
+
+Amongst all the lines the scroll by, you should see one that identifies your command as having been registered:
+
+```
+> Commands
+>   Java Spring Project (Java Spring Project) generate-java-spring-project
+```
+
+In fact, if you type `atomist -h`, you'll also see your command in the output. Try running `atomist generate-java-spring-project`; you'll be asked just for the name of the new repository, and the SDM will go ahead and clone it immediately:
+
+```
+$ atomist generate-java-spring-project
+> Java Spring Project
+> ? name of the new repository my-new-java-project
+> # sdm 2019-05-03 14:37:22 Create Project
+>   Cloning seed project from starting point atomist-seeds/spring-rest at https://github.com/atomist-seeds/spring-rest
+> # sdm 2019-05-03 14:37:23 Create Project
+>   Successfully created new project user/my-new-java-project at file://Users/gjtorikian/atomist/projects/user/my-new-java-project
+```

--- a/docs/developer/setting-up-generator.md
+++ b/docs/developer/setting-up-generator.md
@@ -88,5 +88,7 @@ $ atomist generate-java-spring-project
 > # sdm 2019-05-03 14:37:22 Create Project
 >   Cloning seed project from starting point atomist-seeds/spring-rest at https://github.com/atomist-seeds/spring-rest
 > # sdm 2019-05-03 14:37:23 Create Project
->   Successfully created new project user/my-new-java-project at file://Users/gjtorikian/atomist/projects/user/my-new-java-project
+>   Successfully created new project user/my-new-java-project at file://Users/user/atomist/projects/user/my-new-java-project
 ```
+
+If you navigate to the `~/atomist/projects/user/my-new-java-project` directory, you'll see your brand new generated project!

--- a/docs/developer/setting-up-generator.md
+++ b/docs/developer/setting-up-generator.md
@@ -63,3 +63,5 @@ sdm.addGeneratorCommand(JavaSpringGenerator);
 That's all there is to it!
 
 ## Testing the generator
+
+{!tbd.md!}

--- a/docs/developer/setting-up-generator.md
+++ b/docs/developer/setting-up-generator.md
@@ -6,4 +6,60 @@ In this example, we'll set up a project generator that takes a Java Spring proje
 
 ## Prerequisites
 
+You should already have [a blank SDM](/developer/sdm/#creating-an-sdm-project), though you can also use an existing one if you'd like.
+
 We'll be using the [atomist-seeds/spring-rest](https://github.com/atomist-seeds/spring-rest) repository as our seed. Please don't use this seed for your own Spring projects, as this is just a demo app (and likely full of outdated packages!).
+
+## Registering a generator
+
+Establishing a generator only requires two core arguments: the location of the seed repository, and the name of the command to run to initiate the project.
+
+Open up your SDM, and add a new file called `lib/generator.ts`. Paste the following lines to get started with your generator:
+
+```typescript
+import { GitHubRepoRef } from "@atomist/automation-client";
+import { GeneratorRegistration } from "@atomist/sdm";
+```
+
+The `GitHubRepoRef` function is going to grab a repository off of GitHub based on the parameters you provide it. This could also be in a location like [`GitLabRepoRef`](https://atomist.github.io/automation-client/modules/_lib_operations_common_gitlabreporef_.html) or [`BitBucketRepoRef`](https://atomist.github.io/automation-client/modules/_lib_operations_common_bitbucketreporef_.html) if the repository is hosted somewhere else. In any case, all of the following code will work the same, regardless of the seed's location.
+
+`GeneratorRegistration` is the interface which will actually define the project generation command. Let's fill that out in this file next:
+
+```typescript
+export const JavaSpringGenerator: GeneratorRegistration = {
+  name: "Java Spring Project",
+  intent: "create java-spring project",
+  startingPoint: GitHubRepoRef.from({
+      owner: "atomist-seeds",
+      repo: "spring-rest",
+  }),
+  transform: [],
+};
+```
+
+The arguments are somewhat self-explanatory:
+
+* `name` of the generator. This can be any string.
+* `intent` a string or array of strings; you'll type this to trigger the command.
+* `startingPoint` provides the generator with the location for the seed repository. You can also specify specific SHAs or branches—see [RepoRef](reporef.md) for more details.
+* `transform` is an array of zero or more [code transforms](transform.md) to apply. We won't get into that in this tutorial just yet!
+
+## Adding the generator
+
+Next, in your `machine.ts` file, add the following line to import the file you've just created:
+
+```typescript
+import {
+    JavaSpringGenerator,
+} from "./generator";
+```
+
+Within the SDM logic itself, you'll add the generator via the `addGeneratorCommand` method:
+
+```typescript
+sdm.addGeneratorCommand(JavaSpringGenerator);
+```
+
+That's all there is to it!
+
+## Testing the generator

--- a/docs/developer/setting-up-generator.md
+++ b/docs/developer/setting-up-generator.md
@@ -1,6 +1,6 @@
-If you're working with microservices, at a sufficiently large organization, or just need some uniformity around the repositories your team creates, a [_project generator_](http://localhost:8000/developer/create/) can help you establish a consistent and reproducible framework for your projects.
+If you're working at a sufficiently large organization, architecting several microservices, or just need some uniformity around the repositories your team creates, a [_project generator_](/developer/create/) can help you establish a consistent and reproducible framework for your projects.
 
-A project generator is a type of [command](http://localhost:8000/developer/commands/) which takes a template repository and creates a brand new one from it. It's different from forking in that the generated repository shares no Git history with the original template: it's literally just a copy. These templates repositories are also called _seeds_.
+A project generator is a type of [command](/developer/commands/) which takes a template repository and creates a brand new one from it. It's different from forking in that the generated repository shares no Git history with the original template: it's literally just a copy. These templates repositories are also called _seeds_.
 
 In this example, we'll set up a project generator that takes a Java Spring project with some Maven dependencies configured. (You can generate a project from a seed in any language.)
 

--- a/docs/developer/setting-up-generator.md
+++ b/docs/developer/setting-up-generator.md
@@ -1,0 +1,9 @@
+If you're working with microservices, at a sufficiently large organization, or just need some uniformity around the repositories your team creates, a [_project generator_](http://localhost:8000/developer/create/) can help you establish a consistent and reproducible framework for your projects.
+
+A project generator is a type of [command](http://localhost:8000/developer/commands/) which takes a template repository and creates a brand new one from it. It's different from forking in that the generated repository shares no Git history with the original template: it's literally just a copy. These templates repositories are also called _seeds_.
+
+In this example, we'll set up a project generator that takes a Java Spring project with some Maven dependencies configured. (You can generate a project from a seed in any language.)
+
+## Prerequisites
+
+We'll be using the [atomist-seeds/spring-rest](https://github.com/atomist-seeds/spring-rest) repository as our seed. Please don't use this seed for your own Spring projects, as this is just a demo app (and likely full of outdated packages!).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
         - sdm-pack-sonarqube: https://atomist.github.io/sdm-pack-sonarqube/
   - Tutorials:
       - Building your First Delivery: developer/first_delivery.md
+      - Setting Up a Project Generator: developer/setting-up-generator.md
   - Extensions:
     - Extension Packs: pack/index.md
     - Analysis: pack/analysis.md


### PR DESCRIPTION
This doc was derived from conversations this week on additional material to focus on writing.

Actually, most of the existing doc on [Project Generators](https://docs.atomist.com/developer/create/) was great. I just split the code example into its own stand-alone section and added some more fluff around it.

The next natural tutorial right after this one is on code transforms. 