### PR TITLE
Insert docs into TOC

### DIFF
--- a/docs/developer/invocation.md
+++ b/docs/developer/invocation.md
@@ -1,7 +1,4 @@
-
 Invocation objects provide information to your implementations of [goals](goal.md) and [event listeners](event.md).
-
-## Invocations
 
 These objects, passed to listener functions, contain properties useful for learning about
 the project and for sending messages.

--- a/docs/developer/parseutils.md
+++ b/docs/developer/parseutils.md
@@ -67,7 +67,7 @@ Handy microgrammars to compose:
 
 For more details on how to write a microgrammar, check out the [microgrammar library](https://github.com/atomist/microgrammar), especially the [string-based definition examples](https://github.com/atomist/microgrammar/blob/master/docs/stringDefs.md).
 
-## finding code that looks like this
+## Finding code that looks like this
 
 Within your SDM, you can use [`parseUtils.findMatches`][apidoc-findmatches] to locate all of the
 code that looks like your microgrammar in your entire project.
@@ -104,7 +104,7 @@ If you also want information on the file that each match is in, then check out
 [apidoc-findmatches]: https://atomist.github.io/automation-client/modules/_lib_project_util_parseutils_.html#findmatches (API Doc for findMatches)
 [apidoc-termsdefinition]: https://atomist.github.io/microgrammar/modules/_lib_grammar_.html#termsdefinition (API Doc for TermsDefinition)
 
-## changing code that looks like this
+## Changing code that looks like this
 
 You can update the matched code in place. To do this, use a different function:
 [`parseUtils.doWithMatches`][apidoc-dowithmatches]. This lets you pass in an action,
@@ -143,4 +143,3 @@ Note: if you want information about the file that the match is in, try [`parseUt
 * the [Project API](project.md)
 * do simpler manipulations of file content with [projectUtils](projectutils.md)
 * dig into the abstract syntax tree (AST) of your programming language with [astUtils](astutils.md)
-

--- a/docs/developer/repo-targeting-params.md
+++ b/docs/developer/repo-targeting-params.md
@@ -1,5 +1,3 @@
-# Repo Targeting Parameters
-
 Many commands operate on one or more repositories. For instance, all
 [transform](transform.md) commands run on a repository or more than one repository.
 
@@ -43,4 +41,3 @@ These commands' parameters mix in [RepoTargetingParameters](https://atomist.gith
         If not executing in a mapped channel, must identify a repo via: `targets.owner` and `targets.repo`, or a repo name regex via `targets.repos`
 
     and you did supply `targets.repos`, then it's possible it did not find any matching repositories.
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,16 +75,20 @@ nav:
         - Goals:
             - Create Goals: developer/goal.md
             - Setting Goals: developer/set-goals.md
+            - Goal Details: developer/goaldetails.md
             - Doing More with Goals: developer/goals-more.md
         - Builds:
           - Build Goal: developer/build.md
           - Integrations: user/ci.md
           - Generic Builder: developer/spawn-builder.md
+        - Invocations: developer/invocation.md
         - Deploys: developer/deploy.md
         - Logging: developer/logging.md
+        - Automation API: developer/command-http.md
         - Identifying a repository: developer/reporef.md
         - Custom GraphQL Queries: developer/graphql.md
         - Running External Commands: developer/spawn.md
+        - Repo Targeting Parameters: developer/repo-targeting-params.md
         - HTTP Calls in an SDM: developer/http.md
         - Writing Push Tests: developer/push-test.md
         - Working with the AST: developer/astutils.md
@@ -97,6 +101,8 @@ nav:
             - Autofixes: developer/autofix.md
             - Project: developer/project.md
             - Path Expressions: developer/pxe.md
+            - Using microgrammars: developer/parseutils.md
+            - Modifying files: developer/projectutils.md
         - Chat Messages: developer/slack.md
         - Fingerprints: developer/fingerprint.md
         - Project Generators: developer/create.md


### PR DESCRIPTION
When booting the docs server, it spits out the following warnings:

```
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - developer/command-http.md
  - developer/goaldetails.md
  - developer/invocation.md
  - developer/parseutils.md
  - developer/projectutils.md
  - developer/repo-targeting-params.md
  - user/admin/integrations/github.md 
```

This PR inserts most of those into the TOC, to not hide real issues that could arise in the future.

Only one of these, `user/admin/integrations/github.md `, remains alone. It seems like it's still a TBD doc.