### PR TITLE
Now you can serve the docs locally without installing any Python

### DIFF
--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -1,0 +1,13 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+echo "Welcome to the docs repo"
+
+echo "To serve your current version of the docs, type 'serve' and then visit http://localhost:8000"
+alias serve='mkdocs serve'
+
+echo "To run a strict build and test, type 'build'"
+alias build='mkdocs build --strict && htmltest'
+
+alias ls='ls $LS_OPTIONS'
+alias ll='ls $LS_OPTIONS -l'
+alias l='ls $LS_OPTIONS -lA'
+alias gs='git status'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,62 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+FROM debian:9
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
+# this user's GID/UID must match your local user UID/GID to avoid permission issues
+# with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
+# https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git iproute2 procps lsb-release curl
+# #
+# # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+# && groupadd --gid $USER_GID $USERNAME \
+# && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+# # [Optional] Add sudo support for the non-root user
+# && apt-get install -y sudo \
+# && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+# && chmod 0440 /etc/sudoers.d/$USERNAME \
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=
+
+# Get Python dependencies so we can run mkdocs
+
+RUN apt-get install -y python3-pip
+
+COPY requirements.txt /app/requirements.txt
+
+RUN pip3 install -r /app/requirements.txt
+
+# Set the locale so Python can work
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# When sharing files with Windows, don't get confused by line endings.
+# RUN git config --global core.autocrlf input
+
+# install htmltest
+RUN curl https://htmltest.wjdp.uk | bash -s -- -b /usr/local/bin
+
+# set up aliases
+COPY .bashrc /root
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+# # Clean up apt files. Make the image smaller.
+# RUN apt-get autoremove -y \
+#  && apt-get clean -y \
+#  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/debian-9-git
+{
+	"name": "Debian 9 & Git",
+	"dockerFile": "Dockerfile",
+	// The optional 'runArgs' property can be used to specify additional runtime arguments.
+	"runArgs": [
+		// Uncomment the line if you will use a ptrace-based debugger like C++, Go, and Rust.
+		// "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined",
+		// Uncomment the next line to use a non-root user. On Linux, this will prevent
+		// new files getting created as root, but you may need to update the USER_UID
+		// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
+		// "-u", "vscode"
+	],
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+	// Uncomment the next line if you want to publish any ports.
+	"appPort": [
+		8000
+	],
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": []
+}

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,6 @@
+Markdown==2.6.10
+markdown-include==0.5.1
+mkdocs==1.0.4
+mkdocs-material==3.3.0
+Pygments==2.2.0
+pymdown-extensions==5.0

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Additional links and information are great.
 
 We will move toward a consistent style and tone after merging.
 
-
 ## Build and serve the documentation locally
 
 [build-serve]: #build-and-serve-the-documentation-locally

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [below][build-serve] for instructions on how to test your changes
 locally.
 
 *You are not required to test your changes locally in order to contribute.* Edit right on GitHub,
-and let the build take care of it.
+and let Atomist (our build automation) take care of it.
 
 [doc-style]: https://developers.google.com/style/ (Google Developer Documentation Style Guide)
 [style-highlights]: https://developers.google.com/style/highlights (Google Developer Documentation Style Guide Highlights)
@@ -43,9 +43,119 @@ Here's how I define better:
 
 Additional links and information are great.
 
-We (jessitron) will move toward a consistent style and tone after merging.
+We will move toward a consistent style and tone after merging.
+
+
+## Build and serve the documentation locally
+
+[build-serve]: #build-and-serve-the-documentation-locally
+
+Before you push changes to this repository, you may test your
+changes locally.
+
+### Instant Development environment
+
+If you open this repository in VSCode, and you have Docker, and you have the VSCode extension for remote containers,
+then VSCode will offer to open the folder in a container. Accept that, and you'll have a development environment
+with the right tools installed.
+
+In the terminal inside VSCode, you can type
+
+`serve` and then access your local, hot-reloading version of these docs on localhost:8000.
+
+`build` will build the site and test the links.
+
+You may now skip the rest of this section. Continue with [including code snippets from other repos][code-snippets]
+
+### Working outside Docker
+
+You may need or prefer to install the tools on your computer instead.
+
+#### Install dependencies
+
+The project uses [MkDocs][mkdocs] to generate the static site
+and [htmltest][htmltest] to validate the generated HTML.  Below
+are instructions to install them in a non-obtrusive way.
+
+[htmltest]: https://github.com/wjdp/htmltest
+
+#### MkDocs
+
+First [install Python 3][py-install] using [Homebrew][brew] on Mac OS X.
+
+[py-install]: https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Homebrew-and-Python.md
+[brew]: https://brew.sh/
+
+```
+$ brew install python3 htmltest
+```
+
+or on Debian-based GNU/Linux distributions
+
+```
+$ sudo apt-get install python3-pip htmltest
+```
+
+Then create a [virtual environment][venv] to host the dependencies:
+
+[venv]: https://virtualenv.pypa.io/en/stable/
+
+```
+$ pip3 install virtualenv
+$ mkdir ~/.venvs
+$ echo "export PIP_REQUIRE_VIRTUALENV=true" >> ~/.bashrc
+$ source ~/.bashrc
+$ virtualenv ~/.venvs/docs
+```
+
+With the virtual environment created, activate it in the current
+terminal:
+
+```
+$ . ~/.venvs/docs/bin/activate
+```
+
+and install the dependencies into it:
+
+```
+$ pip install -r requirements.txt
+```
+
+#### Testing and serving
+
+Every time you want to work on this repository, you need to activate
+the Python virtualenv in your working terminal:
+
+```
+$ . ~/.venvs/docs/bin/activate
+```
+
+After making changes, you can test them by building the documentation
+in strict mode.
+
+```
+$ mkdocs build --strict
+```
+
+The run `htmltest`.
+
+```
+$ htmltest -c .htmltest.yml site
+```
+
+To review your changes in a browser, you can serve the documentation
+locally by running:
+
+```
+$ mkdocs serve
+```
+
+and browse the documentation at http://127.0.0.1:8000 .  To stop the
+server, press `Ctrl-C` in the terminal.
 
 ## Code snippets
+
+[code-snippets]: #code-snippets
 
 You can create code snippets in the [atomist/samples][samples]
 repo.  Demarcate a code snippet using the following comment
@@ -130,95 +240,6 @@ If the publication to the docs-sdm bucket is approved, the site is
 
 [docs-sdm]: https://github.com/atomist/docs-sdm
 [docs-sdm-s3]: http://docs-sdm.atomist.com.s3-website-us-west-2.amazonaws.com/
-
-## Build and serve the documentation locally
-
-[build-serve]: #build-and-serve-the-documentation-locally
-
-Before you push changes to this repository, you should test your
-changes locally.
-
-### Install dependencies
-
-The project uses [MkDocs][mkdocs] to generate the static site
-and [htmltest][htmltest] to validate the generated HTML.  Below
-are instructions to install them in a non-obtrusive way.
-
-[htmltest]: https://github.com/wjdp/htmltest
-
-#### MkDocs
-
-First [install Python 3][py-install] using [Homebrew][brew] on Mac OS X.
-
-[py-install]: https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Homebrew-and-Python.md
-[brew]: https://brew.sh/
-
-```
-$ brew install python3 htmltest
-```
-
-or on Debian-based GNU/Linux distributions
-
-```
-$ sudo apt-get install python3-pip htmltest
-```
-
-Then create a [virtual environment][venv] to host the dependencies:
-
-[venv]: https://virtualenv.pypa.io/en/stable/
-
-```
-$ pip3 install virtualenv
-$ mkdir ~/.venvs
-$ echo "export PIP_REQUIRE_VIRTUALENV=true" >> ~/.bashrc
-$ source ~/.bashrc
-$ virtualenv ~/.venvs/docs
-```
-
-With the virtual environment created, activate it in the current
-terminal:
-
-```
-$ . ~/.venvs/docs/bin/activate
-```
-
-and install the dependencies into it:
-
-```
-$ pip install -r requirements.txt
-```
-
-### Testing and serving
-
-Every time you want to work on this repository, you need to activate
-the Python virtualenv in your working terminal:
-
-```
-$ . ~/.venvs/docs/bin/activate
-```
-
-After making changes, you can test them by building the documentation
-in strict mode.
-
-```
-$ mkdocs build --strict
-```
-
-The run `htmltest`.
-
-```
-$ htmltest -c .htmltest.yml site
-```
-
-To review your changes in a browser, you can serve the documentation
-locally by running:
-
-```
-$ mkdocs serve
-```
-
-and browse the documentation at http://127.0.0.1:8000 .  To stop the
-server, press `Ctrl-C` in the terminal.
 
 ### Updating dependencies
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_name: GitHub
 repo_url: https://github.com/atomist/docs
 edit_uri: edit/master/docs/
 copyright: "&copy; 2019 Atomist, Inc."
+dev_addr: 0.0.0.0:8000 # make 'mkdocs serve' work in Docker
 extra:
   main_site_url: https://atomist.com/
   social:


### PR DESCRIPTION
This adds configuration for VSCode's Remote Container extension to work with Docker so that it sets up an environment for you. No more installing python or htmltest locally.